### PR TITLE
Creating an English driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ PHP Number to words converter (WIP)
 [![Code Climate](https://codeclimate.com/github/kwn/number-to-words/badges/gpa.svg)](https://codeclimate.com/github/kwn/number-to-words)
 [![Test Coverage](https://codeclimate.com/github/kwn/number-to-words/badges/coverage.svg)](https://codeclimate.com/github/kwn/number-to-words/coverage)
 
-This library allows you to convert a number to words. 
+This library allows you to convert a number to words.
 
 Installation
 ------------
@@ -31,6 +31,6 @@ Drivers
 
 Language | Number | Currency | Angle | Author
 ---------|--------|----------|-------|-------
-English  | -      | -        | -     | -
+English  | +      | +        | -     | **janhartigan**
 German   | -      | -        | -     | -
 Polish   | +      | +        | -     | **kwn** (ported from dowgird/pyliczba)

--- a/src/Language/English/Dictionary/Currency.php
+++ b/src/Language/English/Dictionary/Currency.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Kwn\NumberToWords\Language\English\Dictionary;
+
+use Kwn\NumberToWords\Model\Currency as CurrencyModel;
+
+class Currency
+{
+    protected $unitNames = [
+        'PLN' => 'złoty',
+        'EUR' => 'euro',
+        'GBP' => 'pound',
+        'USD' => 'dollar',
+        'CHF' => 'franc',
+    ];
+
+    protected $subunitNames = [
+        'PLN' => ['singular' => 'grosz', 'plural' => 'groszy'],
+        'EUR' => ['singular' => 'cent', 'plural' => 'cents'],
+        'GBP' => ['singular' => 'pence', 'plural' => 'pence'],
+        'USD' => ['singular' => 'cent', 'plural' => 'cents'],
+        'CHF' => ['singular' => 'centime', 'plural' => 'centimes'],
+    ];
+
+    /**
+     * Gets all the unit names
+     *
+     * @return array
+     */
+    public function getUnitNames()
+    {
+        return $this->unitNames;
+    }
+
+    /**
+     * Gets a single unit name for the provided currency
+     *
+     * @param CurrencyModel $currency
+     * @param bool $singular
+     *
+     * @return string
+     */
+    public function getUnitName(CurrencyModel $currency, $plural)
+    {
+        return $this->unitNames[$currency->getIdentifier()] . ($plural ? 's' : '');
+    }
+
+    /**
+     * @return array
+     */
+    public function getSubunitNames()
+    {
+        return $this->subunitNames;
+    }
+
+    /**
+     * Gets a single subunit name for the provided currency
+     *
+     * @param CurrencyModel $currency
+     * @param bool $singular
+     *
+     * @return string
+     */
+    public function getSubunitName(CurrencyModel $currency, $plural)
+    {
+        $subunit = $this->subunitNames[$currency->getIdentifier()];
+
+        return $subunit[$plural ? 'plural' : 'singular'];
+    }
+}

--- a/src/Language/English/Dictionary/Number.php
+++ b/src/Language/English/Dictionary/Number.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Kwn\NumberToWords\Language\English\Dictionary;
+
+class Number
+{
+    protected $zero = 'zero';
+
+    protected $units = ['', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine'];
+
+    protected $teens = ['ten', 'eleven', 'twelve', 'thirteen', 'fourteen', 'fifteen',
+        'sixteen', 'seventeen', 'eighteen', 'nineteen'];
+
+    protected $tens = ['', 'ten', 'twenty', 'thirty', 'forty', 'fifty',
+        'sixty', 'seventy', 'eighty', 'ninety'];
+
+    protected $hundred = 'hundred';
+
+    protected $mega = ['', 'thousand', 'million', 'billion', 'trillion', 'quadrillion', 'quintillion', 'sextillion'];
+
+    public function getZero()
+    {
+        return $this->zero;
+    }
+
+    public function getUnit($value)
+    {
+        return $this->units[$value];
+    }
+
+    public function getSubHundred($tens, $units)
+    {
+        $words = [];
+
+        if ($tens === 1) {
+            $words[] = $this->teens[$units];
+        } else {
+            if ($tens > 0) {
+                $words[] = $this->tens[$tens];
+            }
+            if ($units > 0) {
+                $words[] = $this->units[$units];
+            }
+        }
+
+        return implode(' ', $words);
+    }
+
+    public function getHundred($value)
+    {
+        if ($word = $this->getUnit($value))
+            return $word . ' ' . $this->hundred;
+    }
+
+    public function getMega($scale)
+    {
+        if ($word = $this->mega[$scale])
+            return $word;
+    }
+}

--- a/src/Language/English/Transformer/CurrencyTransformer.php
+++ b/src/Language/English/Transformer/CurrencyTransformer.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Kwn\NumberToWords\Language\English\Transformer;
+
+use Kwn\NumberToWords\Model\Amount;
+use Kwn\NumberToWords\Model\Number;
+use Kwn\NumberToWords\Model\Currency;
+use Kwn\NumberToWords\Model\SubunitFormat;
+use Kwn\NumberToWords\Exception\InvalidArgumentException;
+use Kwn\NumberToWords\Language\English\Dictionary\Currency as CurrencyDictionary;
+use Kwn\NumberToWords\Transformer\CurrencyTransformer as CurrencyTransformerInterface;
+
+class CurrencyTransformer implements CurrencyTransformerInterface
+{
+
+    /**
+     * @var NumberTransformer
+     */
+    protected $numberTransformer;
+
+    /**
+     * @var CurrencyDictionary
+     */
+    protected $currencyDictionary;
+
+    /**
+     * @param NumberTransformer $numberTransformer
+     * @param CurrencyDictionary $currencyDictionary
+     */
+    public function __construct(NumberTransformer $numberTransformer, CurrencyDictionary $currencyDictionary)
+    {
+        $this->numberTransformer = $numberTransformer;
+        $this->currencyDictionary = $currencyDictionary;
+    }
+
+    /**
+     * Check if currency definitions exist in dictionary
+     *
+     * @param Currency $currency
+     *
+     * @throws InvalidArgumentException
+     */
+    private function guardAgainstUnexistingCurrency(Currency $currency)
+    {
+        if (!array_key_exists($currency->getIdentifier(), $this->currencyDictionary->getUnitNames())) {
+            throw new InvalidArgumentException(sprintf(
+                'There is missing "%s" unit in a currency dictionary',
+                $currency->getIdentifier()
+            ));
+        }
+
+        if (!array_key_exists($currency->getIdentifier(), $this->currencyDictionary->getSubunitNames())) {
+            throw new InvalidArgumentException(sprintf(
+                'There is missing "%s" subunit in a currency dictionary',
+                $currency->getIdentifier()
+            ));
+        }
+    }
+
+    /**
+     * Convert given number to words
+     *
+     * @param Amount $amount
+     *
+     * @return string
+     */
+    public function toWords(Amount $amount)
+    {
+        $this->guardAgainstUnexistingCurrency($amount->getCurrency());
+
+        return $this->getIntegerPart($amount) . ' ' . $this->getFractionalPart($amount);
+    }
+
+    /**
+     * Gets the integer part of the provided amount
+     *
+     * @param Amount $amount
+     *
+     * @return string
+     */
+    protected function getIntegerPart(Amount $amount)
+    {
+        $number = $amount->getNumber();
+        $unitName = $this->currencyDictionary->getUnitName($amount->getCurrency(), !$this->isSingular($number));
+
+        return $this->numberTransformer->toWords($number) . ' ' . $unitName;
+    }
+
+    /**
+     * Gets the fractional part of the provided amount
+     *
+     * @param Amount $amount
+     *
+     * @return string
+     */
+    protected function getFractionalPart(Amount $amount)
+    {
+        $number = new Number($amount->getNumber()->getSubunits());
+
+        //if the subunit format is numbers, we want to simply return a fraction
+        if ($amount->getSubunitFormat()->getFormat() === SubunitFormat::NUMBERS)
+            return $number->getValue() . '/100';
+
+        $unitName = $this->currencyDictionary->getSubunitName($amount->getCurrency(), !$this->isSingular($number));
+
+        return $this->numberTransformer->toWords($number) . ' ' . $unitName;
+    }
+
+    /**
+     * Determines if the provided number is singular
+     *
+     * @param Number $number
+     *
+     * @return bool
+     */
+    protected function isSingular(Number $number)
+    {
+        return $number->getValue() == 1;
+    }
+}

--- a/src/Language/English/Transformer/NumberTransformer.php
+++ b/src/Language/English/Transformer/NumberTransformer.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Kwn\NumberToWords\Language\English\Transformer;
+
+use Kwn\NumberToWords\Model\Number;
+use Kwn\NumberToWords\Language\English\Dictionary\Number as NumberDictionary;
+use Kwn\NumberToWords\Transformer\NumberTransformer as NumberTransformerInterface;
+
+class NumberTransformer implements NumberTransformerInterface
+{
+    /**
+     * @var NumberDictionary
+     */
+    protected $numberDictionary;
+
+    /**
+     * @param NumberDictionary $numberDictionary
+     */
+    public function __construct(NumberDictionary $numberDictionary)
+    {
+        $this->numberDictionary = $numberDictionary;
+    }
+
+    /**
+     * Return number converted to words
+     *
+     * @param Number $number
+     *
+     * @return string
+     */
+    public function toWords(Number $number)
+    {
+        //if we can't build any triplets, it means we're at (or below) zero
+        if (!$triplets = $this->buildTriplets($number)) {
+            return $this->numberDictionary->getZero();
+        }
+
+        return $this->buildWordsFromTriplets($triplets);
+    }
+
+    /**
+     * Converts the provided number into an array of number triplets
+     * starting at the lowest (i.e. 123456789 => [789, 456, 123])
+     *
+     * @param Number $number
+     *
+     * @return array
+     */
+    protected function buildTriplets(Number $number)
+    {
+        $triplets = [];
+        $value = $number->getValue();
+
+        while ($value > 0) {
+            $triplets[] = $value % 1000;
+            $value      = (int) ($value / 1000);
+        }
+
+        return $triplets;
+    }
+
+    /**
+     * Builds the number word string from the provided set of number triplets
+     *
+     * @param array $triplets
+     *
+     * @return string
+     */
+    protected function buildWordsFromTriplets(array $triplets)
+    {
+        $words = [];
+
+        foreach ($triplets as $i => $triplet) {
+            if ($triplet > 0) {
+                $words[] = trim($this->threeDigitsToWords($triplet) . ' ' . $this->numberDictionary->getMega($i));
+            }
+        }
+
+        return implode(' ', array_reverse($words));
+    }
+
+    /**
+     * Return triplets in words
+     *
+     * @param $value
+     *
+     * @return string
+     */
+    protected function threeDigitsToWords($value)
+    {
+        $units    = $value % 10;
+        $tens     = (int) ($value / 10) % 10;
+        $hundreds = (int) ($value / 100) % 10;
+
+        $words = [];
+
+        if ($hundredsWord = $this->numberDictionary->getHundred($hundreds)) {
+            $words[] = $hundredsWord;
+        }
+
+        if ($subHundredsWord = $this->numberDictionary->getSubHundred($tens, $units)) {
+            $words[] = $subHundredsWord;
+        }
+
+        return implode(' ', $words);
+    }
+}

--- a/src/Language/English/TransformerFactory.php
+++ b/src/Language/English/TransformerFactory.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Kwn\NumberToWords\Language\English;
+
+use Kwn\NumberToWords\Model\Currency;
+use Kwn\NumberToWords\Model\SubunitFormat;
+use Kwn\NumberToWords\Language\English\Transformer\NumberTransformer;
+use Kwn\NumberToWords\Language\English\Transformer\CurrencyTransformer;
+use Kwn\NumberToWords\Language\English\Dictionary\Number as NumberDictionary;
+use Kwn\NumberToWords\Language\English\Dictionary\Currency as CurrencyDictionary;
+use Kwn\NumberToWords\Transformer\TransformerFactory as TransformerFactoryInterface;
+
+class TransformerFactory implements TransformerFactoryInterface
+{
+    /**
+     * Language identifier (RFC 3066)
+     */
+    const LANGUAGE_IDENTIFIER = 'en';
+
+    /**
+     * Language name
+     */
+    const LANGUAGE_NAME = 'English';
+
+    /**
+     * Native language name
+     */
+    const LANGUAGE_NATIVE_NAME = 'English';
+
+    /**
+     * Return language identifier (RFC 3066)
+     *
+     * @return string
+     */
+    public function getLanguageIdentifier()
+    {
+        return self::LANGUAGE_IDENTIFIER;
+    }
+
+    /**
+     * Create number transformer
+     *
+     * @return NumberTransformerInterface
+     */
+    public function createNumberTransformer()
+    {
+        return new NumberTransformer(new NumberDictionary);
+    }
+
+    /**
+     * Create currency transformer
+     *
+     * @param Currency $currency
+     * @param SubunitFormat $currency
+     *
+     * @return CurrencyTransformerInterface
+     */
+    public function createCurrencyTransformer(Currency $currency, SubunitFormat $subunitFormat)
+    {
+        return new CurrencyTransformer($this->createNumberTransformer(), new CurrencyDictionary);
+    }
+}

--- a/src/Language/Polish/Transformer/GrammarCaseAwareTransformer.php
+++ b/src/Language/Polish/Transformer/GrammarCaseAwareTransformer.php
@@ -4,7 +4,6 @@ namespace Kwn\NumberToWords\Language\Polish\Transformer;
 
 use Kwn\NumberToWords\Language\Polish\Grammar\GrammarCaseSelector;
 use Kwn\NumberToWords\Model\Number;
-use Kwn\NumberToWords\Transformer\NumberTransformer;
 
 abstract class GrammarCaseAwareTransformer
 {

--- a/src/Language/Polish/TransformerFactory.php
+++ b/src/Language/Polish/TransformerFactory.php
@@ -2,11 +2,11 @@
 
 namespace Kwn\NumberToWords\Language\Polish;
 
+use Kwn\NumberToWords\Model\Currency;
+use Kwn\NumberToWords\Model\SubunitFormat;
 use Kwn\NumberToWords\Language\Polish\Grammar\GrammarCaseSelector;
 use Kwn\NumberToWords\Language\Polish\Transformer\CurrencyTransformer;
 use Kwn\NumberToWords\Language\Polish\Transformer\NumberTransformer;
-use Kwn\NumberToWords\Transformer\CurrencyTransformer as CurrencyTransformerInterface;
-use Kwn\NumberToWords\Transformer\NumberTransformer as NumberTransformerInterface;
 use Kwn\NumberToWords\Transformer\TransformerFactory as TransformerFactoryInterface;
 
 class TransformerFactory implements TransformerFactoryInterface
@@ -49,9 +49,12 @@ class TransformerFactory implements TransformerFactoryInterface
     /**
      * Create currency transformer
      *
+     * @param Currency $currency
+     * @param SubunitFormat $currency
+     *
      * @return CurrencyTransformerInterface
      */
-    public function createCurrencyTransformer()
+    public function createCurrencyTransformer(Currency $currency, SubunitFormat $subunitFormat)
     {
         return new CurrencyTransformer(new NumberTransformer(new GrammarCaseSelector()), new GrammarCaseSelector());
     }

--- a/src/Language/Romanian/TransformerFactory.php
+++ b/src/Language/Romanian/TransformerFactory.php
@@ -2,10 +2,10 @@
 
 namespace Kwn\NumberToWords\Language\Romanian;
 
+use Kwn\NumberToWords\Model\Currency;
+use Kwn\NumberToWords\Model\SubunitFormat;
 use Kwn\NumberToWords\Language\Romanian\Transformer\CurrencyTransformer;
 use Kwn\NumberToWords\Language\Romanian\Transformer\NumberTransformer;
-use Kwn\NumberToWords\Transformer\CurrencyTransformer as CurrencyTransformerInterface;
-use Kwn\NumberToWords\Transformer\NumberTransformer as NumberTransformerInterface;
 use Kwn\NumberToWords\Transformer\TransformerFactory as TransformerFactoryInterface;
 
 class TransformerFactory implements TransformerFactoryInterface
@@ -48,9 +48,12 @@ class TransformerFactory implements TransformerFactoryInterface
     /**
      * Create currency transformer
      *
+     * @param Currency $currency
+     * @param SubunitFormat $currency
+     *
      * @return CurrencyTransformerInterface
      */
-    public function createCurrencyTransformer()
+    public function createCurrencyTransformer(Currency $currency, SubunitFormat $subunitFormat)
     {
         return new CurrencyTransformer(new NumberTransformer());
     }

--- a/src/Transformer/TransformerFactory.php
+++ b/src/Transformer/TransformerFactory.php
@@ -2,6 +2,8 @@
 
 namespace Kwn\NumberToWords\Transformer;
 
+use Kwn\NumberToWords\Model\Currency;
+use Kwn\NumberToWords\Model\SubunitFormat;
 use Kwn\NumberToWords\Transformer\NumberTransformer as NumberTransformerInterface;
 use Kwn\NumberToWords\Transformer\CurrencyTransformer as CurrencyTransformerInterface;
 
@@ -24,7 +26,10 @@ interface TransformerFactory
     /**
      * Create currency transformer
      *
+     * @param Currency $currency
+     * @param SubunitFormat $currency
+     *
      * @return CurrencyTransformerInterface
      */
-    public function createCurrencyTransformer();
+    public function createCurrencyTransformer(Currency $currency, SubunitFormat $subunitFormat);
 }

--- a/tests/Language/English/Transformer/CurrencyTransformerTest.php
+++ b/tests/Language/English/Transformer/CurrencyTransformerTest.php
@@ -1,0 +1,173 @@
+<?php
+
+namespace Kwn\NumberToWords\Language\English\Transformer;
+
+use Kwn\NumberToWords\Model\Amount;
+use Kwn\NumberToWords\Model\Number;
+use Kwn\NumberToWords\Model\Currency;
+use Kwn\NumberToWords\Model\SubunitFormat;
+use Kwn\NumberToWords\Language\English\Dictionary\Number as NumberDictionary;
+use Kwn\NumberToWords\Language\English\Dictionary\Currency as CurrencyDictionary;
+
+class CurrencyTransformerTest extends \PHPUnit_Framework_TestCase
+{
+    protected $unitNames = [
+        'PLN' => ['unit' => 'złoty', 'subunit' => ['singular' => 'grosz', 'plural' => 'groszy']],
+        'EUR' => ['unit' => 'euro', 'subunit' => ['singular' => 'cent', 'plural' => 'cents']],
+        'GBP' => ['unit' => 'pound', 'subunit' => ['singular' => 'pence', 'plural' => 'pence']],
+        'USD' => ['unit' => 'dollar', 'subunit' => ['singular' => 'cent', 'plural' => 'cents']],
+        'CHF' => ['unit' => 'franc', 'subunit' => ['singular' => 'centime', 'plural' => 'centimes']],
+    ];
+
+    /**
+     * @var CurrencyTransformer
+     */
+    private $transformer;
+
+    public function setUp()
+    {
+        $this->transformer = new CurrencyTransformer(new NumberTransformer(new NumberDictionary), new CurrencyDictionary);
+    }
+
+    /**
+     * @expectedException \Kwn\NumberToWords\Exception\InvalidArgumentException
+     */
+    public function testToWordsThrowsExceptionWithUnknownCurrency()
+    {
+        $amount = new Amount(new Number(50), new Currency('UNK'), new SubunitFormat(SubunitFormat::WORDS));
+
+        $this->transformer->toWords($amount);
+    }
+
+    /**
+     * @dataProvider providerToWordsWithUnitsOnly
+     */
+    public function testToWordsWithUnitsOnly($expectedValue, Amount $amount)
+    {
+        $this->assertEquals($expectedValue, $this->transformer->toWords($amount));
+    }
+
+    public function providerToWordsWithUnitsOnly()
+    {
+        $data = [];
+
+        foreach ($this->unitNames as $code => $currency)
+        {
+            $unitName = $currency['unit'];
+            $pluralSubunitName = $currency['subunit']['plural'];
+
+            $data = array_merge($data, [
+                [
+                    "one {$unitName} zero {$pluralSubunitName}",
+                    new Amount(new Number(1), new Currency($code), new SubunitFormat(SubunitFormat::WORDS))
+                ],
+                [
+                    "two {$unitName}s zero {$pluralSubunitName}",
+                    new Amount(new Number(2), new Currency($code), new SubunitFormat(SubunitFormat::WORDS))
+                ],
+                [
+                    "five {$unitName}s zero {$pluralSubunitName}",
+                    new Amount(new Number(5), new Currency($code), new SubunitFormat(SubunitFormat::WORDS))
+                ],
+                [
+                    "five hundred forty {$unitName}s zero {$pluralSubunitName}",
+                    new Amount(new Number(540), new Currency($code), new SubunitFormat(SubunitFormat::WORDS))
+                ],
+                [
+                    "five hundred forty one {$unitName}s zero {$pluralSubunitName}",
+                    new Amount(new Number(541), new Currency($code), new SubunitFormat(SubunitFormat::WORDS))
+                ],
+                [
+                    "five hundred forty two {$unitName}s zero {$pluralSubunitName}",
+                    new Amount(new Number(542), new Currency($code), new SubunitFormat(SubunitFormat::WORDS))
+                ],
+                [
+                    "five hundred forty four {$unitName}s zero {$pluralSubunitName}",
+                    new Amount(new Number(544), new Currency($code), new SubunitFormat(SubunitFormat::WORDS))
+                ],
+                [
+                    "five hundred forty five {$unitName}s zero {$pluralSubunitName}",
+                    new Amount(new Number(545), new Currency($code), new SubunitFormat(SubunitFormat::WORDS))
+                ]
+            ]);
+        }
+
+        return $data;
+    }
+
+    /**
+     * @dataProvider providerToWordsWithNumbersFormatSubunits
+     */
+    public function testToWordsWithNumbersFormatSubunits($expectedValue, Amount $amount)
+    {
+        $this->assertEquals($expectedValue, $this->transformer->toWords($amount));
+    }
+
+    public function providerToWordsWithNumbersFormatSubunits()
+    {
+        $data = [];
+
+        foreach ($this->unitNames as $code => $currency)
+        {
+            $unitName = $currency['unit'];
+
+            $data = array_merge($data, [
+                [
+                    "five hundred forty five {$unitName}s 52/100",
+                    new Amount(new Number(545.52), new Currency($code), new SubunitFormat(SubunitFormat::NUMBERS))
+                ],
+                [
+                    "five hundred forty five {$unitName}s 0/100",
+                    new Amount(new Number(545), new Currency($code), new SubunitFormat(SubunitFormat::NUMBERS))
+                ],
+                [
+                    "five hundred forty five {$unitName}s 99/100",
+                    new Amount(new Number(545.99), new Currency($code), new SubunitFormat(SubunitFormat::NUMBERS))
+                ]
+            ]);
+        }
+
+        return $data;
+    }
+
+    /**
+     * @dataProvider providerToWordsWithWordsFormatSubunits
+     */
+    public function testToWordsWithWordsFormatSubunits($expectedValue, Amount $amount)
+    {
+        $this->assertEquals($expectedValue, $this->transformer->toWords($amount));
+    }
+
+    public function providerToWordsWithWordsFormatSubunits()
+    {
+        $data = [];
+
+        foreach ($this->unitNames as $code => $currency)
+        {
+            $unitName = $currency['unit'];
+            $singularSubunitName = $currency['subunit']['singular'];
+            $pluralSubunitName = $currency['subunit']['plural'];
+
+            $data = array_merge($data, [
+                [
+                    "five hundred forty five {$unitName}s fifty two {$pluralSubunitName}",
+                    new Amount(new Number(545.52), new Currency($code), new SubunitFormat(SubunitFormat::WORDS))
+                ],
+                [
+                    "five hundred forty five {$unitName}s zero {$pluralSubunitName}",
+                    new Amount(new Number(545), new Currency($code), new SubunitFormat(SubunitFormat::WORDS))
+                ],
+                [
+                    "five hundred forty five {$unitName}s one {$singularSubunitName}",
+                    new Amount(new Number(545.01), new Currency($code), new SubunitFormat(SubunitFormat::WORDS))
+                ],
+                [
+                    "five hundred forty five {$unitName}s ninety nine {$pluralSubunitName}",
+                    new Amount(new Number(545.99), new Currency($code), new SubunitFormat(SubunitFormat::WORDS))
+                ]
+            ]);
+        }
+
+        return $data;
+    }
+}

--- a/tests/Language/English/Transformer/NumberTransformerTest.php
+++ b/tests/Language/English/Transformer/NumberTransformerTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Kwn\NumberToWords\Language\English\Transformer;
+
+use Kwn\NumberToWords\Model\Number;
+use Kwn\NumberToWords\Language\English\Dictionary\Number as NumberDictionary;
+
+class NumberTransformerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var NumberTransformer
+     */
+    private $transformer;
+
+    public function setUp()
+    {
+        $this->transformer = new NumberTransformer(new NumberDictionary);
+    }
+
+    /**
+     * @dataProvider providerToWords
+     */
+    public function testToWords($expectedValue, Number $number)
+    {
+        $this->assertEquals($expectedValue, $this->transformer->toWords($number));
+    }
+
+    public function providerToWords()
+    {
+        return [
+            ['zero', new Number(0)],
+            ['three', new Number(3)],
+            ['three', new Number(3.00)],
+            ['eight', new Number(8.0)],
+            ['ten', new Number(10)],
+            ['twenty', new Number(20)],
+            ['fifty', new Number(50)],
+            ['ninety', new Number(90)],
+            ['twelve', new Number(12)],
+            ['twenty five', new Number(25)],
+            ['fifty eight', new Number(58)],
+            ['ninety nine', new Number(99)],
+            ['one hundred', new Number(100)],
+            ['one hundred two', new Number(102)],
+            ['one hundred thirteen', new Number(113)],
+            ['two hundred twenty nine', new Number(229.0)],
+            ['five hundred', new Number(500.00)],
+            ['six hundred sixty six', new Number(666)],
+            ['six hundred sixty', new Number(660)],
+            ['one thousand', new Number(1000)],
+            ['one thousand one', new Number(1001)],
+            ['one thousand ten', new Number(1010)],
+            ['one thousand fifteen', new Number(1015)],
+            ['one thousand one hundred', new Number(1100)],
+            ['one thousand one hundred eleven', new Number(1111)],
+            ['four thousand five hundred thirty eight', new Number(4538)],
+            ['five thousand twenty', new Number(5020)],
+            ['eleven thousand one', new Number(11001)],
+            ['twenty one thousand five hundred twelve', new Number(21512)],
+            ['ninety thousand', new Number(90000)],
+            ['ninety two thousand one hundred', new Number(92100)],
+            ['two hundred twelve thousand one hundred twelve', new Number(212112)],
+            ['seven hundred twenty thousand eighteen', new Number(720018)],
+            ['one million one thousand one', new Number(1001001)],
+            ['three million two hundred forty eight thousand five hundred eighteen', new Number(3248518)],
+            ['one billion eight hundred million six', new Number(1800000006)],
+        ];
+    }
+}

--- a/tests/Language/English/TransformerFactoryTest.php
+++ b/tests/Language/English/TransformerFactoryTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Kwn\NumberToWords\Language\English;
+
+use Kwn\NumberToWords\Model\Currency;
+use Kwn\NumberToWords\Model\SubunitFormat;
+
+class TransformerFactoryTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var TransformerFactory
+     */
+    private $transformerFactory;
+
+    public function setUp()
+    {
+        $this->transformerFactory = new TransformerFactory();
+    }
+
+    public function testGetLanguageIdentifier()
+    {
+        $this->assertEquals(
+            TransformerFactory::LANGUAGE_IDENTIFIER,
+            $this->transformerFactory->getLanguageIdentifier()
+        );
+    }
+
+    public function testCreateNumberTransformerBuildsCorrectClass()
+    {
+        $numberTransformer = $this->transformerFactory->createNumberTransformer();
+
+        $this->assertInstanceOf(
+            'Kwn\NumberToWords\Language\English\Transformer\NumberTransformer',
+            $numberTransformer
+        );
+    }
+
+    public function testCreateCurrencyTransformerBuildsCorrectClass()
+    {
+        $currencyTransformer = $this->transformerFactory->createCurrencyTransformer(new Currency('USD'), new SubunitFormat(SubunitFormat::WORDS));
+
+        $this->assertInstanceOf(
+            'Kwn\NumberToWords\Language\English\Transformer\CurrencyTransformer',
+            $currencyTransformer
+        );
+    }
+}

--- a/tests/Language/Polish/TransformerFactoryTest.php
+++ b/tests/Language/Polish/TransformerFactoryTest.php
@@ -2,6 +2,9 @@
 
 namespace Kwn\NumberToWords\Language\Polish;
 
+use Kwn\NumberToWords\Model\Currency;
+use Kwn\NumberToWords\Model\SubunitFormat;
+
 class TransformerFactoryTest extends \PHPUnit_Framework_TestCase
 {
     /**
@@ -34,7 +37,7 @@ class TransformerFactoryTest extends \PHPUnit_Framework_TestCase
 
     public function testCreateCurrencyTransformerBuildsCorrectClass()
     {
-        $currencyTransformer = $this->transformerFactory->createCurrencyTransformer();
+        $currencyTransformer = $this->transformerFactory->createCurrencyTransformer(new Currency('PLN'), new SubunitFormat(SubunitFormat::WORDS));
 
         $this->assertInstanceOf(
             'Kwn\NumberToWords\Language\Polish\Transformer\CurrencyTransformer',

--- a/tests/Language/Romanian/TransformerFactoryTest.php
+++ b/tests/Language/Romanian/TransformerFactoryTest.php
@@ -1,7 +1,9 @@
 <?php
 
-
 namespace Kwn\NumberToWords\Language\Romanian;
+
+use Kwn\NumberToWords\Model\Currency;
+use Kwn\NumberToWords\Model\SubunitFormat;
 
 class TransformerFactoryTest extends \PHPUnit_Framework_TestCase
 {
@@ -35,7 +37,7 @@ class TransformerFactoryTest extends \PHPUnit_Framework_TestCase
 
     public function testCreateCurrencyTransformerBuildsCorrectClass()
     {
-        $currencyTransformer = $this->transformerFactory->createCurrencyTransformer();
+        $currencyTransformer = $this->transformerFactory->createCurrencyTransformer(new Currency('PLN'), new SubunitFormat(SubunitFormat::WORDS));
 
         $this->assertInstanceOf(
             'Kwn\NumberToWords\Language\Romanian\Transformer\CurrencyTransformer',


### PR DESCRIPTION
I'm actually a big fan of the way you've set this up, with a few minor exceptions. You set it up to be decently extensible and the architecture gave me some freedom to set up English in such a way that is optimal for its various quirks. Nice job. I'm guessing the biggest reason this is a fairly unused library is because it is made for Polish and Romanian. Since I need an English driver for this library, I made one for you.

Note that there is also a commit that modifies the transformer factory interface a bit to match how you were calling it in [this test](https://github.com/kwn/number-to-words/blob/master/tests/NumberToWordsTest.php#L44-L47). Once I got a bit further into developing the English driver, I realized that the `Amount` instance actually holds a lot of information about how to do the transformation. I suspect that we could get away with simply passing a `Number` to the currency transformer and use the `Currency` and `SubunitFormat` integer from when the transformer is constructed. Seems a bit odd to have a distinct class called `Amount`, which is sort of just another word for "number".

I tried to follow your general style as closely as possible. I made a fairly extensive test suite that tests all currencies for English. Please let me know if you have any questions or comments.