### PR TITLE
Add french currency transformer

### DIFF
--- a/src/CurrencyTransformer/FrenchCurrencyTransformer.php
+++ b/src/CurrencyTransformer/FrenchCurrencyTransformer.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace NumberToWords\CurrencyTransformer;
+
+use NumberToWords\Legacy\Numbers\Words;
+
+class FrenchCurrencyTransformer implements CurrencyTransformer
+{
+    /**
+     * @param int    $amount
+     * @param string $currency
+     *
+     * @return string
+     */
+    public function toWords($amount, $currency)
+    {
+        $converter = new Words();
+
+        return $converter->transformToCurrency($amount, 'fr', $currency);
+    }
+}

--- a/tests/CurrencyTransformer/FrenchCurrencyTransformerTest.php
+++ b/tests/CurrencyTransformer/FrenchCurrencyTransformerTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace NumberToWords\CurrencyTransformer;
+
+class FrenchCurrencyTransformerTest extends CurrencyTransformerTest
+{
+
+    public function setUp()
+    {
+        $this->currencyTransformer = new FrenchCurrencyTransformer();
+    }
+
+    public function providerItConvertsMoneyAmountToWords()
+    {
+        return [
+            [100, 'EUR', 'un euro'],
+            [200, 'EUR', 'deux euros'],
+            [235715, 'EUR', 'deux mille trois cent cinquante-sept euros et quinze centimes'],
+            [1522501, 'EUR', 'quinze mille deux cent vingt-cinq euros et un centime'],
+            [754414599, 'USD', 'sept millions cinq cent quarante-quatre mille cent quarante-cinq dollars américains et quatre-vingt-dix-neuf cents'],
+            [754414599, 'CAD', 'sept millions cinq cent quarante-quatre mille cent quarante-cinq dollars canadiens et quatre-vingt-dix-neuf cents'],
+            [754414599, 'AUD', 'sept millions cinq cent quarante-quatre mille cent quarante-cinq dollars australiens et quatre-vingt-dix-neuf cents'],
+        ];
+    }
+}


### PR DESCRIPTION
I didn't add GBP nor SEK since they have a different gender. Thus the number converter needs to have a different value when it ends with one. At the moment, I can output 'un livre' instead of 'une livre' for instance.
Suggestions are welcomed.