### PR TITLE
Throw exception for unknown currencies

### DIFF
--- a/src/Legacy/Numbers/Words/Locale/Es.php
+++ b/src/Legacy/Numbers/Words/Locale/Es.php
@@ -298,7 +298,6 @@ class Es extends Words
         }
 
         $currencyNames = static::$currencyNames[$currency];
-        // $currencyNames = self::$currencyNames[$currency];
 
         $level = ($decimal == 1) ? 0 : 1;
 

--- a/src/Legacy/Numbers/Words/Locale/Es.php
+++ b/src/Legacy/Numbers/Words/Locale/Es.php
@@ -3,6 +3,7 @@
 namespace NumberToWords\Legacy\Numbers\Words\Locale;
 
 use NumberToWords\Legacy\Numbers\Words;
+use NumberToWords\Exception\NumberToWordsException;
 
 class Es extends Words
 {
@@ -288,7 +289,16 @@ class Es extends Words
      */
     public function toCurrencyWords($currency, $decimal, $fraction = null)
     {
-        $currencyNames = self::$currencyNames[$currency];
+        $currency = strtoupper($currency);
+
+        if (!array_key_exists($currency, static::$currencyNames)) {
+            throw new NumberToWordsException(
+                sprintf('Currency "%s" is not available for "%s" language', $currency, get_class($this))
+            );
+        }
+
+        $currencyNames = static::$currencyNames[$currency];
+        // $currencyNames = self::$currencyNames[$currency];
 
         $level = ($decimal == 1) ? 0 : 1;
 


### PR DESCRIPTION
I have updated the legacy Spanish locale to throw NumberToWordsException for unknown currencies.