### PR TITLE
Lithuanian language currency transformer

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ French               | fr         | +      | +        |
 Hungarian            | hu         | +      | +        |
 Indonesian           | id         | +      | -        |
 Italian              | it         | +      | -        |
-Lithuanian           | lt         | +      | -        |
+Lithuanian           | lt         | +      | +        |
 Latvian              | lv         | +      | -        |
 Malay                | ms         | +      | -        |
 Polish               | pl         | +      | +        |

--- a/src/CurrencyTransformer/LithuanianCurrencyTransformer.php
+++ b/src/CurrencyTransformer/LithuanianCurrencyTransformer.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace NumberToWords\CurrencyTransformer;
+
+use NumberToWords\Exception\NumberToWordsException;
+use NumberToWords\Language\English\EnglishDictionary;
+use NumberToWords\Language\English\EnglishExponentGetter;
+use NumberToWords\Language\English\EnglishTripletTransformer;
+use NumberToWords\Language\Lithuania\LithuaniaDictionary;
+use NumberToWords\NumberTransformer\NumberTransformerBuilder;
+use NumberToWords\Service\NumberToTripletsConverter;
+use NumberToWords\NumberTransformer\LithuanianNumberTransformer;
+
+function dd(...$item) {
+    var_dump($item); die();
+}
+
+class LithuanianCurrencyTransformer implements CurrencyTransformer
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @throws NumberToWordsException
+     * @return string
+     */
+    public function toWords($amount, $currency, $options = null)
+    {
+        $dictionary = new LithuaniaDictionary();
+        $numberTransformer = new LithuanianNumberTransformer();
+
+        $decimal = (int) ($amount / 100);
+        $fraction = abs($amount % 100);
+
+        if ($fraction === 0) {
+            $fraction = null;
+        }
+
+        $currency = strtoupper($currency);
+
+        if (!array_key_exists($currency, LithuaniaDictionary::$currencyNames)) {
+            throw new NumberToWordsException(
+                sprintf('Currency "%s" is not available for "%s" language', $currency, get_class($this))
+            );
+        }
+
+        $currencyNames = LithuaniaDictionary::$currencyNames[$currency];
+
+        $return = trim($numberTransformer->toWords($decimal));
+        $level = $this->getLevel($decimal);
+
+        $return .= ' ' . $currencyNames[0][$level];
+
+        if (null !== $fraction) {
+            $return .= ' ' . $dictionary->getAnd() . ' ' . trim($numberTransformer->toWords($fraction));
+
+            $level = $this->getLevel($fraction);
+
+            $return .= ' ' . $currencyNames[1][$level];
+        } else {
+            $level = 1;
+
+            $return .= ' ' . $dictionary->getAnd() . ' ' . $dictionary->getZero() . ' ' . $currencyNames[1][$level];
+        }
+
+        return $return;
+    }
+
+    /**
+     * @param $number
+     * @return int
+     */
+    public function getLevel($number)
+    {
+        $lastTwoDigits = $number % 100;
+        $lastDigit = $number % 10;
+        $isUnit = log($number) === 1;
+
+        if ($number === 0) {
+            return 1;
+        }
+
+        if (!$isUnit && $lastDigit === 0) {
+            return 1;
+        }
+
+        if (10 <= $lastTwoDigits && $lastTwoDigits <= 20) {
+            return 1;
+        }
+
+        if ($number === 1) {
+            return 0;
+        }
+
+        if (!$isUnit && $lastDigit === 1) {
+            return 0;
+        }
+
+        return 2;
+    }
+}

--- a/src/CurrencyTransformer/LithuanianCurrencyTransformer.php
+++ b/src/CurrencyTransformer/LithuanianCurrencyTransformer.php
@@ -11,10 +11,6 @@ use NumberToWords\NumberTransformer\NumberTransformerBuilder;
 use NumberToWords\Service\NumberToTripletsConverter;
 use NumberToWords\NumberTransformer\LithuanianNumberTransformer;
 
-function dd(...$item) {
-    var_dump($item); die();
-}
-
 class LithuanianCurrencyTransformer implements CurrencyTransformer
 {
     /**
@@ -50,7 +46,7 @@ class LithuanianCurrencyTransformer implements CurrencyTransformer
 
         $return .= ' ' . $currencyNames[0][$level];
 
-        if (null !== $fraction) {
+        if (!is_null($fraction)) {
             $return .= ' ' . $dictionary->getAnd() . ' ' . trim($numberTransformer->toWords($fraction));
 
             $level = $this->getLevel($fraction);

--- a/src/Language/Lithuania/LithuaniaDictionary.php
+++ b/src/Language/Lithuania/LithuaniaDictionary.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace NumberToWords\Language\Lithuania;
+
+use NumberToWords\Language\Dictionary;
+
+class LithuaniaDictionary implements Dictionary
+{
+    const LOCALE               = 'lt';
+    const LANGUAGE_NAME        = 'Lithuanian';
+    const LANGUAGE_NAME_NATIVE = 'Lietuvių';
+
+    /** @var array<string>  */
+    private static $units = [
+        0 => 'nulis',
+        1 => 'vienas',
+        2 => 'du',
+        3 => 'trys',
+        4 => 'keturi',
+        5 => 'penki',
+        6 => 'šeši',
+        7 => 'septyni',
+        8 => 'aštuoni',
+        9 => 'devyni'
+    ];
+
+    /** @var array<string>  */
+    private static $tens = [
+        0 => 'dešimt',
+        1 => 'vienuolika',
+        2 => 'dvylika',
+        3 => 'trylika',
+        4 => 'keturiolika',
+        5 => 'penkiolika',
+        6 => 'šešiolika',
+        7 => 'septyniolika',
+        8 => 'aštuoniolika',
+        9 => 'devyniolika'
+    ];
+
+    /** @var array<string>  */
+    private static $teens = [
+        0 => '',
+        1 => 'dešimt',
+        2 => 'dvidešimt',
+        3 => 'trisdešimt',
+        4 => 'keturiasdešimt',
+        5 => 'penkiasdešimt',
+        6 => 'šešiasdešimt',
+        7 => 'septyniasdešimt',
+        8 => 'aštuoniasdešimt',
+        9 => 'devyniasdešimt'
+    ];
+
+    /** @var array<string>  */
+    private static $hundreds = [
+        0 => 'šimtas',
+        2 => 'šimtai',
+    ];
+
+    /** @var array<array<string>>  */
+    public static $exponent = [
+        ['', ''],
+        ['tūkstantis', 'tūkstančių', 'tūkstančiai'],
+        ['milijonas', 'milijonų', 'milijonai'],
+        ['bilijonas', 'bilijonų', 'bilijonai'],
+        ['trilijonas', 'trilijonų', 'trilijardai'],
+        ['kvadrilijonas', 'kvadrilijonų', 'kvadrilijonai'],
+        ['kvintilijonas', 'kvintilijonų', 'kvintilijonai'],
+        ['sikstilijonas', 'sikstilijonų', 'sikstilijonai'],
+        ['septilijonas', 'septilijonų', 'septilijonai'],
+        ['oktilijonas', 'oktilijonų', 'oktilijonai'],
+        ['nonilijonas', 'nonilijonų', 'nonilijonai'],
+        ['gugolas', 'gugolų', 'gugolai'],
+        ['gugolplexas', 'gugolplexų', 'gugolplexai']
+    ];
+
+    /** @var array<array<string>>  */
+    public static $currencyNames = [
+        'EUR' => [['euras', 'eurų', 'eurai'], ['euro centas', 'euro centų', 'euro centai']],
+        'LT' => [['litas', 'litų', 'litai'], ['lito centas', 'lito centų', 'lito centai']],
+    ];
+
+    /**
+     * @return string
+     */
+    public function getAnd()
+    {
+        return 'ir';
+    }
+
+    /**
+     * @return string
+     */
+    public function getMinus()
+    {
+        return 'minus';
+    }
+
+    /**
+     * @return string
+     */
+    public function getZero()
+    {
+        return 'nulis';
+    }
+
+    /**
+     * @param int $unit
+     *
+     * @return string
+     */
+    public function getCorrespondingUnit($unit)
+    {
+        return self::$units[$unit];
+    }
+
+    /**
+     * @param int $ten
+     *
+     * @return string
+     */
+    public function getCorrespondingTen($ten)
+    {
+        return self::$tens[$ten];
+    }
+
+    /**
+     * @param int $teen
+     *
+     * @return string
+     */
+    public function getCorrespondingTeen($teen)
+    {
+        return self::$teens[$teen];
+    }
+
+    /**
+     * @param int $hundred
+     *
+     * @return string
+     */
+    public function getCorrespondingHundred($hundred)
+    {
+        if ($hundred === 1) {
+            return static::$hundreds[0];
+        }
+
+        return self::$units[$hundred] . ' ' . static::$hundreds[1];
+    }
+}

--- a/src/NumberToWords.php
+++ b/src/NumberToWords.php
@@ -7,6 +7,7 @@ use NumberToWords\CurrencyTransformer\GeorgianCurrencyTransformer;
 use NumberToWords\CurrencyTransformer\GermanCurrencyTransformer;
 use NumberToWords\CurrencyTransformer\DanishCurrencyTransformer;
 use NumberToWords\CurrencyTransformer\EnglishCurrencyTransformer;
+use NumberToWords\CurrencyTransformer\LithuanianCurrencyTransformer;
 use NumberToWords\CurrencyTransformer\PolishCurrencyTransformer;
 use NumberToWords\CurrencyTransformer\PortugueseBrazilianCurrencyTransformer;
 use NumberToWords\CurrencyTransformer\RomanianCurrencyTransformer;
@@ -87,6 +88,7 @@ class NumberToWords
         'fr' => FrenchCurrencyTransformer::class,
         'hu' => HungarianNumberTransformer::class,
         'ka' => GeorgianCurrencyTransformer::class,
+        'lt' => LithuanianCurrencyTransformer::class,
         'pl' => PolishCurrencyTransformer::class,
         'pt_BR' => PortugueseBrazilianCurrencyTransformer::class,
         'ro' => RomanianCurrencyTransformer::class,

--- a/tests/CurrencyTransformer/LithuaniaCurrencyTransformerTest.php
+++ b/tests/CurrencyTransformer/LithuaniaCurrencyTransformerTest.php
@@ -8,7 +8,7 @@ class LithuaniaCurrencyTransformerTest extends CurrencyTransformerTest
     {
         $this->currencyTransformer = new LithuanianCurrencyTransformer();
     }
- 
+
     public function providerItConvertsMoneyAmountToWords()
     {
         return array_merge([

--- a/tests/CurrencyTransformer/LithuaniaCurrencyTransformerTest.php
+++ b/tests/CurrencyTransformer/LithuaniaCurrencyTransformerTest.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace NumberToWords\CurrencyTransformer;
+
+class LithuaniaCurrencyTransformerTest extends CurrencyTransformerTest
+{
+    public function setUp()
+    {
+        $this->currencyTransformer = new LithuanianCurrencyTransformer();
+    }
+ 
+    public function providerItConvertsMoneyAmountToWords()
+    {
+        return array_merge([
+            [0, 'EUR', 'nulis eurų ir nulis euro centų'],
+            [1, 'EUR', 'nulis eurų ir vienas euro centas'],
+            [9, 'EUR', 'nulis eurų ir devyni euro centai'],
+            [10, 'EUR', 'nulis eurų ir dešimt euro centų'],
+            [11, 'EUR', 'nulis eurų ir vienuolika euro centų'],
+            [19, 'EUR', 'nulis eurų ir devyniolika euro centų'],
+            [20, 'EUR', 'nulis eurų ir dvidešimt euro centų'],
+            [21, 'EUR', 'nulis eurų ir dvidešimt vienas euro centas'],
+            [25, 'EUR', 'nulis eurų ir dvidešimt penki euro centai'],
+            [30, 'EUR', 'nulis eurų ir trisdešimt euro centų'],
+            [99, 'EUR', 'nulis eurų ir devyniasdešimt devyni euro centai'],
+            [100, 'EUR', 'vienas euras ir nulis euro centų'],
+            [101, 'EUR', 'vienas euras ir vienas euro centas'],
+            [103, 'EUR', 'vienas euras ir trys euro centai'],
+            [111, 'EUR', 'vienas euras ir vienuolika euro centų'],
+            [120, 'EUR', 'vienas euras ir dvidešimt euro centų'],
+            [121, 'EUR', 'vienas euras ir dvidešimt vienas euro centas'],
+            [726, 'EUR', 'septyni eurai ir dvidešimt šeši euro centai'],
+            [850, 'EUR', 'aštuoni eurai ir penkiasdešimt euro centų'],
+            [900, 'EUR', 'devyni eurai ir nulis euro centų'],
+            [919, 'EUR', 'devyni eurai ir devyniolika euro centų'],
+            [930, 'EUR', 'devyni eurai ir trisdešimt euro centų'],
+            [990, 'EUR', 'devyni eurai ir devyniasdešimt euro centų'],
+            [999, 'EUR', 'devyni eurai ir devyniasdešimt devyni euro centai'],
+            [1000, 'EUR', 'dešimt eurų ir nulis euro centų'],
+            [1001, 'EUR', 'dešimt eurų ir vienas euro centas'],
+            [2000, 'EUR', 'dvidešimt eurų ir nulis euro centų'],
+            [3000, 'EUR', 'trisdešimt eurų ir nulis euro centų'],
+            [3210, 'EUR', 'trisdešimt du eurai ir dešimt euro centų'],
+            [4000, 'EUR', 'keturiasdešimt eurų ir nulis euro centų'],
+            [4011, 'EUR', 'keturiasdešimt eurų ir vienuolika euro centų'],
+            [7000, 'EUR', 'septyniasdešimt eurų ir nulis euro centų'],
+            [11000, 'EUR', 'šimtas dešimt eurų ir nulis euro centų'],
+            [21000, 'EUR', 'du šimtai dešimt eurų ir nulis euro centų'],
+            [999000, 'EUR', 'devyni tūkstančiai devyni šimtai devyniasdešimt eurų ir nulis euro centų'],
+            [999999, 'EUR', 'devyni tūkstančiai devyni šimtai devyniasdešimt devyni eurai ir devyniasdešimt devyni euro centai'],
+            [1000000, 'EUR', 'dešimt tūkstančių eurų ir nulis euro centų'],
+            [2500001, 'EUR', 'dvidešimt penki tūkstančiai eurų ir vienas euro centas'],
+
+            [1174315110, 'EUR', 'vienuolika milijonų septyni šimtai keturiasdešimt trys tūkstančiai šimtas penkiasdešimt vienas euras ir dešimt euro centų'], // or "vienas bilijonas"
+            [1174315119, 'EUR', 'vienuolika milijonų septyni šimtai keturiasdešimt trys tūkstančiai šimtas penkiasdešimt vienas euras ir devyniolika euro centų'], // or "vienas bilijonas"
+            [15174315110, 'EUR', 'šimtas penkiasdešimt vienas milijonas septyni šimtai keturiasdešimt trys tūkstančiai šimtas penkiasdešimt vienas euras ir dešimt euro centų'],
+            [35174315119, 'EUR', 'trys šimtai penkiasdešimt vienas milijonas septyni šimtai keturiasdešimt trys tūkstančiai šimtas penkiasdešimt vienas euras ir devyniolika euro centų'],
+            [935174315119, 'EUR', 'devyni bilijonai trys šimtai penkiasdešimt vienas milijonas septyni šimtai keturiasdešimt trys tūkstančiai šimtas penkiasdešimt vienas euras ir devyniolika euro centų'],
+            [222935174315119, 'EUR', 'du trilijonai du šimtai dvidešimt devyni bilijonai trys šimtai penkiasdešimt vienas milijonas septyni šimtai keturiasdešimt trys tūkstančiai šimtas penkiasdešimt vienas euras ir devyniolika euro centų'],
+        ], [
+            [0, 'LT', 'nulis litų ir nulis lito centų'],
+            [1, 'LT', 'nulis litų ir vienas lito centas'],
+            [9, 'LT', 'nulis litų ir devyni lito centai'],
+            [10, 'LT', 'nulis litų ir dešimt lito centų'],
+            [11, 'LT', 'nulis litų ir vienuolika lito centų'],
+            [19, 'LT', 'nulis litų ir devyniolika lito centų'],
+            [20, 'LT', 'nulis litų ir dvidešimt lito centų'],
+            [21, 'LT', 'nulis litų ir dvidešimt vienas lito centas'],
+            [25, 'LT', 'nulis litų ir dvidešimt penki lito centai'],
+            [30, 'LT', 'nulis litų ir trisdešimt lito centų'],
+            [99, 'LT', 'nulis litų ir devyniasdešimt devyni lito centai'],
+            [100, 'LT', 'vienas litas ir nulis lito centų'],
+            [101, 'LT', 'vienas litas ir vienas lito centas'],
+            [103, 'LT', 'vienas litas ir trys lito centai'],
+            [111, 'LT', 'vienas litas ir vienuolika lito centų'],
+            [120, 'LT', 'vienas litas ir dvidešimt lito centų'],
+            [121, 'LT', 'vienas litas ir dvidešimt vienas lito centas'],
+            [726, 'LT', 'septyni litai ir dvidešimt šeši lito centai'],
+            [850, 'LT', 'aštuoni litai ir penkiasdešimt lito centų'],
+            [900, 'LT', 'devyni litai ir nulis lito centų'],
+            [919, 'LT', 'devyni litai ir devyniolika lito centų'],
+            [930, 'LT', 'devyni litai ir trisdešimt lito centų'],
+            [990, 'LT', 'devyni litai ir devyniasdešimt lito centų'],
+            [999, 'LT', 'devyni litai ir devyniasdešimt devyni lito centai'],
+            [1000, 'LT', 'dešimt litų ir nulis lito centų'],
+            [1001, 'LT', 'dešimt litų ir vienas lito centas'],
+            [2000, 'LT', 'dvidešimt litų ir nulis lito centų'],
+            [3000, 'LT', 'trisdešimt litų ir nulis lito centų'],
+            [3210, 'LT', 'trisdešimt du litai ir dešimt lito centų'],
+            [4000, 'LT', 'keturiasdešimt litų ir nulis lito centų'],
+            [4011, 'LT', 'keturiasdešimt litų ir vienuolika lito centų'],
+            [7000, 'LT', 'septyniasdešimt litų ir nulis lito centų'],
+            [11000, 'LT', 'šimtas dešimt litų ir nulis lito centų'],
+            [21000, 'LT', 'du šimtai dešimt litų ir nulis lito centų'],
+            [999000, 'LT', 'devyni tūkstančiai devyni šimtai devyniasdešimt litų ir nulis lito centų'],
+            [999999, 'LT', 'devyni tūkstančiai devyni šimtai devyniasdešimt devyni litai ir devyniasdešimt devyni lito centai'],
+            [1000000, 'LT', 'dešimt tūkstančių litų ir nulis lito centų'],
+            [2500001, 'LT', 'dvidešimt penki tūkstančiai litų ir vienas lito centas'],
+
+            [1174315110, 'LT', 'vienuolika milijonų septyni šimtai keturiasdešimt trys tūkstančiai šimtas penkiasdešimt vienas litas ir dešimt lito centų'], // or "vienas bilijonas"
+            [1174315119, 'LT', 'vienuolika milijonų septyni šimtai keturiasdešimt trys tūkstančiai šimtas penkiasdešimt vienas litas ir devyniolika lito centų'], // or "vienas bilijonas"
+            [15174315110, 'LT', 'šimtas penkiasdešimt vienas milijonas septyni šimtai keturiasdešimt trys tūkstančiai šimtas penkiasdešimt vienas litas ir dešimt lito centų'],
+            [35174315119, 'LT', 'trys šimtai penkiasdešimt vienas milijonas septyni šimtai keturiasdešimt trys tūkstančiai šimtas penkiasdešimt vienas litas ir devyniolika lito centų'],
+            [935174315119, 'LT', 'devyni bilijonai trys šimtai penkiasdešimt vienas milijonas septyni šimtai keturiasdešimt trys tūkstančiai šimtas penkiasdešimt vienas litas ir devyniolika lito centų'],
+            [222935174315119, 'LT', 'du trilijonai du šimtai dvidešimt devyni bilijonai trys šimtai penkiasdešimt vienas milijonas septyni šimtai keturiasdešimt trys tūkstančiai šimtas penkiasdešimt vienas litas ir devyniolika lito centų'],
+        ]);
+    }
+}


### PR DESCRIPTION
Added lithuanian currencty transformem functionality. 

There was a lithuanian number converter, but no ability to transform lithuanian type of currecy.

Also there is two types of currency in Lithuania. old one - litas, and new one - euro.