### PR TITLE
UGX ENGLISH CURRENCY TRANSFORMER

### DIFF
--- a/src/CurrencyTransformer/EnglishCurrencyTransformer.php
+++ b/src/CurrencyTransformer/EnglishCurrencyTransformer.php
@@ -31,8 +31,8 @@ class EnglishCurrencyTransformer implements CurrencyTransformer
             ->useRegularExponents($exponentInflector)
             ->build();
 
-        $decimal = (int) ($amount / 100);
-        $fraction = abs($amount % 100);
+        $decimal = $currency != 'UGX' ? (int) ($amount / 100) : (int) ($amount);
+        $fraction = $currency != 'UGX' ? abs($amount % 100) : abs($amount % 1);
 
         if ($fraction === 0) {
             $fraction = null;

--- a/src/Language/English/EnglishDictionary.php
+++ b/src/Language/English/EnglishDictionary.php
@@ -88,6 +88,7 @@ class EnglishDictionary implements Dictionary
         'XPF' => [['CFP franc'], ['centime']],
         'YUM' => [['dinar'], ['para']],
         'ZAR' => [['rand'], ['cent']],
+        'UGX' => [['ugandan shilling']],
     ];
 
     /**

--- a/tests/CurrencyTransformer/EnglishCurrencyTransformerTest.php
+++ b/tests/CurrencyTransformer/EnglishCurrencyTransformerTest.php
@@ -31,6 +31,15 @@ class EnglishCurrencyTransformerTest extends CurrencyTransformerTest
             [-72925, 'USD', 'minus seven hundred twenty-nine dollars twenty-five cents'],
             [-89425, 'USD', 'minus eight hundred ninety-four dollars twenty-five cents'],
             [-99925, 'USD', 'minus nine hundred ninety-nine dollars twenty-five cents'],
+            [25000, 'UGX', 'twenty-five thousand ugandan shillings'],
+            [2500, 'UGX', 'two thousand five hundred ugandan shillings'],
+            [250, 'UGX', 'two hundred fifty ugandan shillings'],
+            [100, 'UGX', 'one hundred ugandan shillings'],
+            [1150000, 'UGX', 'one million one hundred fifty thousand ugandan shillings'],
+            [25, 'UGX', 'twenty-five ugandan shillings'],
+            [1025, 'UGX', 'one thousand twenty-five ugandan shillings'],
+            [-1025, 'UGX', 'minus one thousand twenty-five ugandan shillings'],
+            [123456789, 'UGX', 'one hundred twenty-three million four hundred fifty-six thousand seven hundred eighty-nine ugandan shillings'],
         ];
     }
 }


### PR DESCRIPTION
## UGX ENGLISH CURRENCY TRANSFORMER
    1. Added UGX in English Dictionary for currency transformer to words.
    2. Modified toWords function in EnglishCurrencyTransformer to consider UGX decimals and fraction.

The addition has been tested. Please review and merge.