### PR TITLE
Fix php 8.1 float to int deprecation warning

### DIFF
--- a/src/Legacy/Numbers/Words/Locale/It.php
+++ b/src/Legacy/Numbers/Words/Locale/It.php
@@ -32,7 +32,7 @@ class It extends Words
         'sei',
         'sette',
         'otto',
-        'nove'
+        'nove',
     ];
 
     private $wordSeparator = '';
@@ -83,8 +83,8 @@ class It extends Words
             $ret .= $this->toWords($thousands, 3) . $this->wordSeparator;
         }
 
-        $hundreds = (int) ($number / 100 % 10);
-        $tens = (int) ($number / 10 % 10);
+        $hundreds = (int) ($number % 1000 / 100);
+        $tens = (int) ($number % 100 / 10);
         $units = (int) ($number % 10);
 
         // centinaia: duecento, trecento, etc...

--- a/src/Legacy/Numbers/Words/Locale/Ka.php
+++ b/src/Legacy/Numbers/Words/Locale/Ka.php
@@ -18,7 +18,6 @@ class Ka extends Words
     const FRACTION_PREFIX = ' მე';
     const FRACTION_SUFFIX = 'ედი';
 
-
     private static $dictionary = [
         0 => 'ნულ',
         1 => 'ერთ',
@@ -68,7 +67,7 @@ class Ka extends Words
         'TRY' => [['ლირა'], ['ყურუში']],
         'AMD' => [['დრამი'], ['ლუმა']],
         'PLN' => [['ზლოტი'], ['გროში']],
-        'GBP' => [['ფუნტი'], ['პენი']]
+        'GBP' => [['ფუნტი'], ['პენი']],
     ];
 
     public function toCurrencyWords($currency, $decimal, $fraction = null)
@@ -139,7 +138,7 @@ class Ka extends Words
                 }
                 break;
             case $number < 1000:
-                $hundreds = $number / 100;
+                $hundreds = (int) ($number % 1000 / 100);
                 $remainder = $number % 100;
                 $hundredsStr = $hundreds < 2 ? '' : self::$dictionary[$hundreds];
                 $string = $hundredsStr . self::$dictionary[100];
@@ -176,6 +175,5 @@ class Ka extends Words
 
         return $string;
     }
-
 
 }


### PR DESCRIPTION
Italian and Kazakhi language files were giving a deprecation warning in PHP 8.1 regarding float to integer conversion

[PHP Watch Information on this warning](https://php.watch/versions/8.1/deprecate-implicit-conversion-incompatible-float-string)