### PR TITLE
GBP support for French Locale

### DIFF
--- a/src/Legacy/Numbers/Words/Locale/Fr.php
+++ b/src/Legacy/Numbers/Words/Locale/Fr.php
@@ -97,6 +97,7 @@ class Fr extends Words
         'CNY' => [['yuan'], ['fen']],
         'DZD' => [['dinar'], ['centime']],
         'EUR' => [['euro'], ['centime']],
+        'GBP' => [['livre sterling', 'livres sterling'], ['penny', 'pence']],
         'JPY' => [['yen', ['sen']]],
         'LYD' => [['dinar'], ['centime']],
         'MAD' => [['dirham'], ['centime']],

--- a/src/Legacy/Numbers/Words/Locale/Fr.php
+++ b/src/Legacy/Numbers/Words/Locale/Fr.php
@@ -97,7 +97,7 @@ class Fr extends Words
         'CNY' => [['yuan'], ['fen']],
         'DZD' => [['dinar'], ['centime']],
         'EUR' => [['euro'], ['centime']],
-        'GBP' => [['livre sterling', 'livres sterling'], ['penny', 'pence']],
+        'GBP' => [['pound', 'pounds'], ['penny', 'pence']],
         'JPY' => [['yen', ['sen']]],
         'LYD' => [['dinar'], ['centime']],
         'MAD' => [['dirham'], ['centime']],

--- a/tests/CurrencyTransformer/FrenchCurrencyTransformerTest.php
+++ b/tests/CurrencyTransformer/FrenchCurrencyTransformerTest.php
@@ -20,6 +20,10 @@ class FrenchCurrencyTransformerTest extends CurrencyTransformerTest
             [754414599, 'AUD', 'sept millions cinq cent quarante-quatre mille cent quarante-cinq dollars australiens et quatre-vingt-dix-neuf cents'],
             [754414599, 'CAD', 'sept millions cinq cent quarante-quatre mille cent quarante-cinq dollars canadiens et quatre-vingt-dix-neuf cents'],
             [754414599, 'USD', 'sept millions cinq cent quarante-quatre mille cent quarante-cinq dollars américains et quatre-vingt-dix-neuf cents'],
+            [100, 'GBP', 'un livre sterling'],
+            [1000, 'GBP', 'dix livres sterling'],
+            [70001, 'GBP', 'sept cents livres sterling et un penny'],
+            [700010, 'GBP', 'sept mille livres sterling et dix pence'],
         ];
     }
 }

--- a/tests/CurrencyTransformer/FrenchCurrencyTransformerTest.php
+++ b/tests/CurrencyTransformer/FrenchCurrencyTransformerTest.php
@@ -20,10 +20,10 @@ class FrenchCurrencyTransformerTest extends CurrencyTransformerTest
             [754414599, 'AUD', 'sept millions cinq cent quarante-quatre mille cent quarante-cinq dollars australiens et quatre-vingt-dix-neuf cents'],
             [754414599, 'CAD', 'sept millions cinq cent quarante-quatre mille cent quarante-cinq dollars canadiens et quatre-vingt-dix-neuf cents'],
             [754414599, 'USD', 'sept millions cinq cent quarante-quatre mille cent quarante-cinq dollars américains et quatre-vingt-dix-neuf cents'],
-            [100, 'GBP', 'un livre sterling'],
-            [1000, 'GBP', 'dix livres sterling'],
-            [70001, 'GBP', 'sept cents livres sterling et un penny'],
-            [700010, 'GBP', 'sept mille livres sterling et dix pence'],
+            [100, 'GBP', 'un pound'],
+            [1000, 'GBP', 'dix pounds'],
+            [70001, 'GBP', 'sept cents pounds et un penny'],
+            [700010, 'GBP', 'sept mille pounds et dix pence'],
         ];
     }
 }


### PR DESCRIPTION
We have added the "Livre sterling (GBP)" in the french locale.