### PR TITLE
Added transformer options (convert fraction and convert fraction if zero) to Latvian currency transformer

### DIFF
--- a/src/CurrencyTransformer/LatvianCurrencyTransformer.php
+++ b/src/CurrencyTransformer/LatvianCurrencyTransformer.php
@@ -37,15 +37,29 @@ class LatvianCurrencyTransformer implements CurrencyTransformer
         $return .= ' ' . $currencyNames[0][$level];
 
         if (!is_null($fraction)) {
-            $return .= ' ' . $dictionary->getAnd() . ' ' . trim($numberTransformer->toWords($fraction));
+            $return .= ' ' . $dictionary->getAnd();
+
+            if ($options->isConvertFraction()) {
+                $return .= ' ' . trim($numberTransformer->toWords($fraction));
+            } else {
+                $return .= ' ' . trim($fraction);
+            }
 
             $level = $this->getLevel($fraction);
 
             $return .= ' ' . $currencyNames[1][$level];
         } else {
+            $return .= ' ' . $dictionary->getAnd();
+
+            if ($options->isConvertFraction() && $options->isConvertFractionIfZero()) {
+                $return .= ' ' . $dictionary->getZero();
+            } else {
+                $return .= ' 0';
+            }
+
             $level = 1;
 
-            $return .= ' ' . $dictionary->getAnd() . ' ' . $dictionary->getZero() . ' ' . $currencyNames[1][$level];
+            $return .= ' ' . $currencyNames[1][$level];
         }
 
         return $return;

--- a/src/CurrencyTransformer/LatvianCurrencyTransformer.php
+++ b/src/CurrencyTransformer/LatvianCurrencyTransformer.php
@@ -11,6 +11,8 @@ class LatvianCurrencyTransformer implements CurrencyTransformer
 {
     public function toWords(int $amount, string $currency, ?CurrencyTransformerOptions $options = null): string
     {
+        if (is_null($options)) $options = new CurrencyTransformerOptions();
+
         $dictionary = new LatvianDictionary();
         $numberTransformer = new LatvianNumberTransformer();
 


### PR DESCRIPTION
In invoices (in Latvia) we provide the total amount in words where decimal part is provided as words but fraction part is provided as number (for example "one euro and 12 cents").
By default LatvianCurrencyTransformer will return all parts as words (functionality not changed). 