### PR TITLE
Add MXN to EnglishDictionary currencies

### DIFF
--- a/src/Language/English/EnglishDictionary.php
+++ b/src/Language/English/EnglishDictionary.php
@@ -71,6 +71,7 @@ class EnglishDictionary implements Dictionary
         'MKD' => [['Macedonian dinar'], ['deni']],
         'MRO' => [['ouguiya'], ['khoums']],
         'MTL' => [['Maltese lira'], ['centym']],
+        'MXN' => [['Mexican peso'], ['cent']],
         'NGN' => [['Naira'], ['kobo']],
         'NOK' => [['Norwegian krone'], ['oere']],
         'PHP' => [['peso'], ['centavo']],


### PR DESCRIPTION
Add MXN to EnglishDictionary currencies as Mexican peso and cent