### PR TITLE
Fix typo with Romanian currency key

### DIFF
--- a/src/Language/English/EnglishDictionary.php
+++ b/src/Language/English/EnglishDictionary.php
@@ -75,7 +75,7 @@ class EnglishDictionary implements Dictionary
         'NOK' => [['Norwegian krone'], ['oere']],
         'PHP' => [['peso'], ['centavo']],
         'PLN' => [['zloty', 'zlotys'], ['grosz']],
-        'ROL' => [['Romanian leu'], ['bani']],
+        'RON' => [['Romanian leu'], ['bani']],
         'RUB' => [['Russian Federation rouble'], ['kopiejka']],
         'SAR' => [['Riyal'], ['Halalah']],
         'SEK' => [['Swedish krona'], ['oere']],


### PR DESCRIPTION
While using this package for invoice generation we noticed that in english the Romanian lei currency have a wrong code in the dictionary. 

This pull requests changes it from ROL to RON which is the correct code.